### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single **Vite + React 19 SPA** (a catalog of self-contained front-end experiments). All "API" traffic is mocked in-browser by **Mock Service Worker (MSW)** — there is **no backend, database, or external service** to run. See `CLAUDE.md` for the full architecture and the canonical command list (`pnpm dev`, `pnpm build`, `pnpm lint`, `pnpm typecheck`, `pnpm e2e`, etc.).
+
+### Running the app
+- `pnpm dev` starts the only runtime process (Vite dev server on `http://localhost:5173`). MSW starts automatically inside the browser before React renders; no separate command is needed.
+- The startup update script only runs `pnpm install`. Everything else (dev server, tests) is started manually.
+
+### Node / package manager
+- `node` resolves to a system `v22.14.0` in this environment (fine — Vite 8 needs Node ≥ 22.12), even though `package.json` pins Node `24.12.0` via Volta and `README.md`/`CLAUDE.md` mention older versions. The version discrepancy across docs is pre-existing and does not block dev/build.
+- `pnpm` (10.21.0, matching `packageManager`) is already available in fresh shells; do not reinstall it.
+
+### e2e tests (Playwright)
+- Playwright's Chromium browser must be installed once per fresh VM before running e2e: `pnpm exec playwright install chromium` (binaries are cached under `~/.cache/ms-playwright` and persist in the VM snapshot). It is intentionally **not** in the update script to keep startup lightweight and avoid a large download on every boot.
+- `pnpm e2e` auto-starts the dev server via Playwright's `webServer` config, so you do not need to start `pnpm dev` first.
+
+### Known pre-existing breakages (do NOT treat as environment problems; do not "fix" as part of setup)
+- **`pnpm lint` and `pnpm typecheck` fail on `main`** and this is reproduced by CI (Lint + Typecheck jobs are red; Build is green). Causes: TypeScript 7 removed the `baseUrl` tsconfig option, and `@typescript-eslint` 8.59.1 (pulled transitively) is incompatible with TypeScript 7 (`Cannot read properties of undefined (reading 'Cjs')`). `pnpm build` still succeeds.
+- **Several experiment pages crash at runtime** with `classed.header is not a function` because `@/components/Header` uses `classed-components@2.0.1`, which is broken with the current React 19 / Vite 8 bundle. Affected routes include `/mixi`, `/useoptimistic`, `/dateform`, `/imageupload`, `/arrayform`, `/contextmenu`, `/multi-file-upload`, `/windowOpen`, `/urlparams`, `/sandbox`, `/tailwindlineclamp`. `pnpm build` does not catch these because the bundler never executes the code.
+- The `/search` experiment fetches the absolute `http://localhost:3000/api/search`, but the MSW handler is registered for the relative `/api/search` (origin `:5173`), so the search request is not mocked and fails with `ERR_CONNECTION_REFUSED`.
+- Some `e2e` specs (`toppage`, `mui-migration`, `tailwind-line-clamp`) are **stale** and fail because the landing-page labels/pages changed; `context.spec.ts` passes. e2e is not part of CI.
+
+### Reliable pages for smoke-testing the environment
+`/` (landing), `/form` (React Hook Form: validation + submit), `/formobservatory` (live form-state lab), and `/context` (Context API demo) all render and work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Vite + React 19 experimental workspace so Cloud Agents can install deps, run lint/typecheck/build, run e2e, and run the app. Adds `AGENTS.md` documenting durable, non-obvious startup/run caveats.

The only code change is the new `AGENTS.md` — no application code was modified.

## Environment

- **Node**: system `v22.14.0` (satisfies Vite 8's ≥22.12 requirement; `package.json` Volta pin of `24.12.0` and older docs are a pre-existing discrepancy).
- **pnpm**: `10.21.0` (already available), deps installed via `pnpm install`.
- **Update script**: `pnpm install` (minimal, idempotent). Playwright browsers are installed on-demand (`pnpm exec playwright install chromium`) and cached in the snapshot, kept out of the update script to keep startup lightweight.

## Verification

| Check | Command | Result |
|---|---|---|
| Install | `pnpm install --frozen-lockfile` | ✅ |
| Build | `pnpm build` | ✅ |
| Lint | `pnpm lint` | ❌ pre-existing (also red in CI) |
| Typecheck | `pnpm typecheck` | ❌ pre-existing (also red in CI) |
| e2e | `pnpm e2e` | ⚠️ 8 pass / 16 stale-test failures (e2e not in CI) |
| Run app | `pnpm dev` → hello-world via UI | ✅ |

`lint`/`typecheck` failures are reproduced by CI on `main` (TypeScript 7 removed `baseUrl`; `@typescript-eslint` 8.59.1 incompatible with TS 7). Build is green. These are not environment issues and were intentionally not fixed.

## Hello-world demo

Landing page → React Hook Form (validation errors → valid submit) → Form Observatory (live form-state updates). All working core experiments render without errors.

[react_workspace_hello_world_demo.mp4](https://cursor.com/agents/bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_workspace_hello_world_demo.mp4)

[Landing page](https://cursor.com/agents/bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page.webp)
[Form validation errors](https://cursor.com/agents/bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fform_validation_errors.webp)
[Form Observatory live state](https://cursor.com/agents/bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fform_observatory_live_state.webp)

## Notes for future agents (also in AGENTS.md)

Several experiment routes crash at runtime with `classed.header is not a function` (broken `classed-components@2.0.1` in `@/components/Header`): `/mixi`, `/useoptimistic`, `/dateform`, `/imageupload`, and others. `/search` fails because it fetches `http://localhost:3000/api/search` while MSW mocks the relative `/api/search`. These are pre-existing and out of scope for env setup.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f781721a-da5f-4e83-b3cd-f74e9e88d50f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

